### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,17 +7,17 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-LcdHistogram KEYWORD1
-GraphMode KEYWORD1
+LcdHistogram	KEYWORD1
+GraphMode	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-push KEYWORD2
-plot KEYWORD2
-setBounds KEYWORD2
-setMode KEYWORD2
+push	KEYWORD2
+plot	KEYWORD2
+setBounds	KEYWORD2
+setMode	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords